### PR TITLE
Remove duplicate parenthesis and unnecessary spaces from parameter txt files

### DIFF
--- a/models/Par0013/Par0013GC_GD_singleImage.txt
+++ b/models/Par0013/Par0013GC_GD_singleImage.txt
@@ -17,7 +17,7 @@
 
 (Optimizer "ConjugateGradient")
 (Transform "EulerTransform")
-(Metric "GradientDifference"))
+(Metric "GradientDifference")
 
 // ***************** Transformation **************************
 

--- a/models/Par0020/Par0020affine.txt
+++ b/models/Par0020/Par0020affine.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 //(AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-// (AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+// (AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0020/Par0020rigid.txt
+++ b/models/Par0020/Par0020rigid.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "true")
 (AutomaticTransformInitializationMethod "CenterOfGravity")
-// (AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+// (AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0025/Par0025affine.txt
+++ b/models/Par0025/Par0025affine.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "false")
 (AutomaticTransformInitializationMethod "CenterOfGravity")
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-//(AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+//(AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0025/Par0025rigid.txt
+++ b/models/Par0025/Par0025rigid.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "true")
 (AutomaticTransformInitializationMethod "CenterOfGravity")
-// (AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+// (AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0026/Par0026affine.txt
+++ b/models/Par0026/Par0026affine.txt
@@ -64,8 +64,8 @@
 
 //THE DEFAULT WAS NONE!!!???...BUT FOR THE LM_25211 16M->14M IT IS NOT WORKING
 
-(AutomaticTransformInitializationMethod " GeometricalCenter")
-//(AutomaticTransformInitializationMethod " Origins")
+(AutomaticTransformInitializationMethod "GeometricalCenter")
+//(AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0026/Par0026rigid.txt
+++ b/models/Par0026/Par0026rigid.txt
@@ -64,8 +64,8 @@
 
 //THE DEFAULT WAS CENTER OF GRAVITY...BUT FOR THE LM_25211 16M->14M IT IS NOT WORKING
 
-(AutomaticTransformInitializationMethod " GeometricalCenter")
-//(AutomaticTransformInitializationMethod " Origins")
+(AutomaticTransformInitializationMethod "GeometricalCenter")
+//(AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0033/Par0033rigid.txt
+++ b/models/Par0033/Par0033rigid.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-(AutomaticTransformInitializationMethod " GeometricalCenter")
-//(AutomaticTransformInitializationMethod " Origins")
+(AutomaticTransformInitializationMethod "GeometricalCenter")
+//(AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0034/Par0034affine.txt
+++ b/models/Par0034/Par0034affine.txt
@@ -65,8 +65,8 @@
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
 
 
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-(AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+(AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0034/Par0034rigid.txt
+++ b/models/Par0034/Par0034rigid.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-(AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+(AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0038/Par0038affine.txt
+++ b/models/Par0038/Par0038affine.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 //(AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0038/Par0038rigid.txt
+++ b/models/Par0038/Par0038rigid.txt
@@ -64,8 +64,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0056/Par0056affine.txt
+++ b/models/Par0056/Par0056affine.txt
@@ -60,8 +60,8 @@
 // geometric centers of the fixed and moving.
 //(AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.

--- a/models/Par0056/Par0056rigid.txt
+++ b/models/Par0056/Par0056rigid.txt
@@ -64,8 +64,8 @@
 // geometric centers of the fixed and moving.
 (AutomaticTransformInitialization "true")
 //(AutomaticTransformInitializationMethod "CenterOfGravity")
-//(AutomaticTransformInitializationMethod " GeometricalCenter")
-// (AutomaticTransformInitializationMethod " Origins")
+//(AutomaticTransformInitializationMethod "GeometricalCenter")
+// (AutomaticTransformInitializationMethod "Origins")
 
 // Whether transforms are combined by composition or by addition.
 // In generally, Compose is the best option in most cases.


### PR DESCRIPTION
Encountered these minor flaws when trying to convert those file to another file format (YAML).

@mstaring @stefanklein @ViktorvdValk Just for your information!