### PR TITLE
BUG: Fix elastix parameters specified more than once in Par0004, Par0008

### DIFF
--- a/models/Par0004/Par0004.bs_base.NRU08.txt
+++ b/models/Par0004/Par0004.bs_base.NRU08.txt
@@ -25,7 +25,6 @@
 // Sampling
 (NewSamplesEveryIteration "true" "true" "true" "true")
 (NumberOfSpatialSamples 5000 5000 5000 5000)
-(NewSamplesEveryIteration "true" "true")
 (ErodeMask "true" "true")
 
 // Interpolation and resampling

--- a/models/Par0008/Parameters.Par0008.elastic.txt
+++ b/models/Par0008/Parameters.Par0008.elastic.txt
@@ -27,6 +27,7 @@
 (BSplineInterpolationOrder 1)
 
 //Order of B-Spline interpolation used for applying the final deformation:
+//Note, February 2025: the intended/preferred FinalBSplineInterpolationOrder value may have been 3
 (FinalBSplineInterpolationOrder 0)
 
 //Final spacing of B-Spline grid (unit = size of 1 voxel):
@@ -55,12 +56,6 @@
 
 //Number of spatial samples used to compute the mutual information in each resolution level:
 (NumberOfSpatialSamples 4096 4096 4096 4096 4096)
-
-//Order of B-Spline interpolation used in each resolution level:
-(BSplineInterpolationOrder 1 1 1 1 1)
-
-//Order of B-Spline interpolation used for applying the final deformation:
-(FinalBSplineInterpolationOrder 3)
 
 //Default pixel value for pixels that come from outside the picture:
 (DefaultPixelValue 0)


### PR DESCRIPTION
From October 13, 2009 (commit https://github.com/SuperElastix/elastix/commit/2c72f70c738c7f95067747af486216223e1e2268) elastix produces an error message on these two parameter files, saying "The parameter is specified more than once". Before then, it would just ignore the second occurrence of a parameter that is specified twice.

This commit removes the second occurrence of those parameters, as discussed with Marius Staring. It should not have any effect on the registration, when using an old version of elastix (from before October 13, 2009).

A note is added to Par0008, as FinalBSplineInterpolationOrder may not have the intended value.

- Addresses issue https://github.com/SuperElastix/ElastixModelZoo/issues/13 "Par0004.bs_base.NRU08, Parameters.Par0008.elastic parameters specified more than once"