### PR TITLE
DOC: Update URLs of manual and Model Zoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elastix Model Zoo
 Welcome to the Model Zoo for parameter settings in Elastix, ITKElastix and SimpleElastix.
-All models are displayed at https://elastix.lumc.nl/modelzoo, but static content including parameter files can be found here in the _models_ directory.
+All models are displayed at https://lkeb.ml/modelzoo but static content including parameter files can be found here in the _models_ directory.
 
 How to Upload Model Parameters
 ----------

--- a/models/Par0002/README.md
+++ b/models/Par0002/README.md
@@ -59,4 +59,4 @@ See the [elastix manual][5] for hints on how to subsequently apply the transform
 
 [4] P. Thevenaz, M. Bierlaire and M. Unser, "Halton Sampling for Image Registration Based on Mutual Information", Sampling Theory in Signal and Image Processing, vol. 7, no. 2, pp. 141 - 171, 2008.
 
-[5]: https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf
+[5]: https://github.com/SuperElastix/elastix/releases/download/5.2.0/elastix-5.2.0-manual.pdf

--- a/models/Par0003/README.md
+++ b/models/Par0003/README.md
@@ -60,4 +60,4 @@ See the [elastix manual][3] for hints on how to subsequently apply the transform
 
 [2] K. Murphy, B. van Ginneken, J. P. W. Pluim, S. Klein, and M. Staring, "Semi-automatic reference standard construction for quantitative evaluation of lung CT registration," in MICCAI, ser. Lecture Notes in Computer Science, vol. 5242, 2008, pp. 1006 – 1013.
 
-[3]: https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf
+[3]: https://github.com/SuperElastix/elastix/releases/download/5.2.0/elastix-5.2.0-manual.pdf

--- a/models/default/README.md
+++ b/models/default/README.md
@@ -26,4 +26,4 @@ The files are saved in DOS text format. In order to use them on a Linux-based sy
 
 ### Other comments
 
-See the [elastix manual](https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf) for an extensive introduction to <tt>elastix</tt> and explanation of many parameters. If you have any questions, please subscribe to the <tt>elastix</tt> mailing list and post your question there. We (the authors of <tt>elastix</tt>) are happy to answer any questions. Please do read the [FAQ](https://github.com/SuperElastix/elastix/wiki/FAQ) though ;)
+See the [elastix manual](https://github.com/SuperElastix/elastix/releases/download/5.2.0/elastix-5.2.0-manual.pdf) for an extensive introduction to <tt>elastix</tt> and explanation of many parameters. If you have any questions, please subscribe to the <tt>elastix</tt> mailing list and post your question there. We (the authors of <tt>elastix</tt>) are happy to answer any questions. Please do read the [FAQ](https://github.com/SuperElastix/elastix/wiki/FAQ) though ;)


### PR DESCRIPTION
- Following the announcement "New website: https://elastix.dev", Jun 21, 2024 at https://github.com/SuperElastix/elastix/discussions/1158